### PR TITLE
feat: add prompt-fit preflight methods to Python bridge

### DIFF
--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -306,3 +306,84 @@ Different artifact formats require fundamentally different data preparation path
 
 The narrative format needs **chronological segment detail**, while card/standup need 
 **thematic grouping**.
+
+## Artifact Generation Cancellation (Apr 2026)
+
+### Investigation Summary
+
+User request: "Add cancellation support to Python bridge for artifact generation."
+
+### Architecture Findings
+
+**Communication Protocol:**
+- **Transport**: Unix domain socket (`/tmp/escribano-recorder-vlm.sock`)
+- **Protocol**: NDJSON (one JSON object per line)
+- **Message Format**: `{"id": <number>, "method": "<method>", "params": {...}}`
+
+**Generation Flow:**
+```
+Swift UI → ViewModel → GenerateArtifact → InferenceQueue → PythonBridgeAdapter → Unix Socket → mlx_bridge.py → MLX generate()
+```
+
+Artifact generation makes **2 sequential LLM calls**:
+1. Subject grouping (maxTokens: 4000)
+2. Artifact prose (maxTokens: 2000)
+
+### Core Problem
+
+**The MLX library's `generate()` function does NOT support mid-generation cancellation.**
+
+Evidence from `mlx_bridge.py`:
+```python
+signal.signal(signal.SIGALRM, timeout_handler)
+signal.alarm(300)  # 5 min timeout - ONLY cancellation mechanism
+try:
+    output = generate(llm_model, llm_tokenizer, prompt=prompt, ...)
+```
+
+The `generate()` function:
+- Runs synchronously and blocks until completion
+- No `cancellation_callback` or `should_stop` flag
+- No streaming/token-by-token interruption hooks
+- Python bridge is single-threaded — can't process messages while blocked
+
+### Options Evaluated
+
+| Option | Feasibility | Trade-offs |
+|--------|-------------|------------|
+| **Out-of-band signal** | ❌ | Python blocked on `generate()`, can't process messages |
+| **Cooperative cancellation** | ❌ | Requires forking/modifying upstream `mlx-lm` library |
+| **Process termination** | ✅ Works | Kills ALL inference (frame analysis too), 30-120s model reload |
+| **Socket disconnect** | ⚠️ Partial | Python keeps running, wastes GPU, unstable state |
+
+### Decision: Don't Implement
+
+**Reasons:**
+1. **Technical limitation**: MLX lacks cancellation support
+2. **Cost vs benefit**: Process termination is too destructive
+3. **UX penalty**: 30-120 second model reload is worse than waiting
+4. **Architecture impact**: Would disrupt frame analysis pipeline
+
+### Alternative UX Improvements (Implementable)
+
+1. **Progress indication** — Show which step is running (grouping vs prose)
+2. **Estimated time** — Display approximate completion based on token count
+3. **Background generation** — Allow closing window while generation continues
+4. **Queue visibility** — Show if artifact generation is waiting behind frame analysis
+
+### Future Possibility
+
+If MLX adds cancellation support:
+- Swift `WorkQueue` already uses `withTaskCancellationHandler`
+- Clean propagation path exists, just needs bridge-level hook
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `escribano-ts/scripts/mlx_bridge.py` | Python bridge server (766 lines) |
+| `apps/recorder/Sources/PythonBridge.vlm.adapter.swift` | Swift bridge adapter (527 lines) |
+| `apps/recorder/Sources/WorkQueue.swift` | Inference queue with cancellation support (351 lines) |
+| `apps/recorder/Sources/GenerateArtifact.swift` | Artifact generation use case (226 lines) |
+| `apps/recorder/Sources/EscribanoWindowViewModel.swift` | View model for UI (140 lines) |
+| `apps/recorder/Sources/GenerateView.swift` | Generation UI (70 lines) |

--- a/scripts/mlx_bridge.py
+++ b/scripts/mlx_bridge.py
@@ -454,12 +454,12 @@ def handle_request(
             )
             return
 
-        if BRIDGE_MODE == "vlm" and method == "llm_infer":
+        if BRIDGE_MODE == "vlm" and method in ("llm_infer", "llm_prompt_fit"):
             send_response(
                 conn,
                 {
                     "id": request_id,
-                    "error": "llm_infer not available in VLM-only mode",
+                    "error": f"{method} not available in VLM-only mode",
                     "done": True,
                 },
             )
@@ -518,39 +518,47 @@ def handle_request(
                     from mlx_lm import generate
                     from mlx_lm.sample_utils import make_sampler
 
-                    messages = params.get("messages", [])
-                    raw_prompt = params.get("rawPrompt")
                     max_tokens = params.get("maxTokens", 8000)
                     temperature = params.get("temperature", 0.7)
                     think = params.get("think", False)
 
-                    # Determine prompt source and apply chat template
-                    if raw_prompt:
-                        # Apply chat template to raw prompt
-                        chat_messages = [{"role": "user", "content": raw_prompt}]
-                        prompt = llm_tokenizer.apply_chat_template(
-                            chat_messages,
-                            tokenize=False,
-                            add_generation_prompt=True,
-                            chat_template_kwargs={"enable_thinking": think},
-                        )
-                        log(
-                            f"Applied chat template to raw prompt (think={think}, temp={temperature})",
-                            "debug",
-                        )
-                    elif messages:
-                        # Apply chat template to messages array
-                        prompt = llm_tokenizer.apply_chat_template(
-                            messages,
-                            tokenize=False,
-                            add_generation_prompt=True,
-                            chat_template_kwargs={"enable_thinking": think},
-                        )
-                        log(
-                            f"Applied chat template to messages (think={think}, temp={temperature})",
-                            "debug",
-                        )
-                    else:
+                    def build_llm_prompt(tokenizer_obj: Any, prompt_params: dict) -> str | None:
+                        messages = prompt_params.get("messages", [])
+                        raw_prompt = prompt_params.get("rawPrompt")
+                        think_enabled = prompt_params.get("think", False)
+
+                        if raw_prompt:
+                            chat_messages = [{"role": "user", "content": raw_prompt}]
+                            built_prompt = tokenizer_obj.apply_chat_template(
+                                chat_messages,
+                                tokenize=False,
+                                add_generation_prompt=True,
+                                chat_template_kwargs={"enable_thinking": think_enabled},
+                            )
+                            log(
+                                f"Applied chat template to raw prompt (think={think_enabled}, temp={temperature})",
+                                "debug",
+                            )
+                            return built_prompt
+
+                        if messages:
+                            built_prompt = tokenizer_obj.apply_chat_template(
+                                messages,
+                                tokenize=False,
+                                add_generation_prompt=True,
+                                chat_template_kwargs={"enable_thinking": think_enabled},
+                            )
+                            log(
+                                f"Applied chat template to messages (think={think_enabled}, temp={temperature})",
+                                "debug",
+                            )
+                            return built_prompt
+
+                        return None
+
+                    prompt = build_llm_prompt(llm_tokenizer, params)
+
+                    if prompt is None:
                         send_response(
                             conn,
                             {
@@ -636,6 +644,140 @@ def handle_request(
 
                 except Exception as e:
                     log(f"Text generation failed: {e}", "error")
+                    send_response(
+                        conn, {"id": request_id, "error": str(e), "done": True}
+                    )
+        elif method == "llm_prompt_fit":
+            if llm_model is None or llm_tokenizer is None:
+                send_response(
+                    conn,
+                    {"id": request_id, "error": "LLM model not loaded", "done": True},
+                )
+            else:
+                try:
+                    requested_output_tokens = int(params.get("maxTokens", 8000))
+                    reserved_tokens = 24000
+                    fallback_context_limit = 262144
+
+                    def build_llm_prompt(tokenizer_obj: Any, prompt_params: dict) -> str | None:
+                        messages = prompt_params.get("messages", [])
+                        raw_prompt = prompt_params.get("rawPrompt")
+                        think_enabled = prompt_params.get("think", False)
+
+                        if raw_prompt:
+                            chat_messages = [{"role": "user", "content": raw_prompt}]
+                            built_prompt = tokenizer_obj.apply_chat_template(
+                                chat_messages,
+                                tokenize=False,
+                                add_generation_prompt=True,
+                                chat_template_kwargs={"enable_thinking": think_enabled},
+                            )
+                            log(
+                                f"Applied chat template to raw prompt for fit check (think={think_enabled})",
+                                "debug",
+                            )
+                            return built_prompt
+
+                        if messages:
+                            built_prompt = tokenizer_obj.apply_chat_template(
+                                messages,
+                                tokenize=False,
+                                add_generation_prompt=True,
+                                chat_template_kwargs={"enable_thinking": think_enabled},
+                            )
+                            log(
+                                f"Applied chat template to messages for fit check (think={think_enabled})",
+                                "debug",
+                            )
+                            return built_prompt
+
+                        return None
+
+                    def count_prompt_tokens(tokenizer_obj: Any, prompt_text: str) -> int:
+                        tokenized = tokenizer_obj.encode(prompt_text)
+                        input_ids = getattr(tokenized, "input_ids", tokenized)
+                        if isinstance(input_ids, dict):
+                            input_ids = input_ids.get("input_ids", [])
+                        if isinstance(input_ids, list) and input_ids and isinstance(input_ids[0], list):
+                            return len(input_ids[0])
+                        return len(input_ids)
+
+                    def resolve_context_limit(model_ref: Any, tokenizer_obj: Any) -> int:
+                        candidates = [
+                            getattr(model_ref, "config", None),
+                            getattr(model_ref, "args", None),
+                            tokenizer_obj,
+                            getattr(tokenizer_obj, "tokenizer", None),
+                        ]
+                        field_names = (
+                            "max_position_embeddings",
+                            "max_seq_len",
+                            "model_max_length",
+                            "max_length",
+                            "context_length",
+                            "n_ctx",
+                        )
+
+                        for candidate in candidates:
+                            if candidate is None:
+                                continue
+                            for field_name in field_names:
+                                value = getattr(candidate, field_name, None)
+                                if isinstance(value, int) and value > 0 and value < 10_000_000:
+                                    return value
+
+                        log(
+                            f"Context limit metadata unavailable for request {request_id}; using fallback {fallback_context_limit}",
+                            "error",
+                        )
+                        return fallback_context_limit
+
+                    prompt = build_llm_prompt(llm_tokenizer, params)
+
+                    if prompt is None:
+                        send_response(
+                            conn,
+                            {
+                                "id": request_id,
+                                "error": "No prompt provided (need 'rawPrompt' or 'messages')",
+                                "done": True,
+                            },
+                        )
+                        return
+
+                    if not prompt:
+                        send_response(
+                            conn,
+                            {
+                                "id": request_id,
+                                "error": "Empty prompt after template",
+                                "done": True,
+                            },
+                        )
+                        return
+
+                    prompt_tokens = count_prompt_tokens(llm_tokenizer, prompt)
+                    context_limit = resolve_context_limit(llm_model, llm_tokenizer)
+                    safe_input_budget = (
+                        context_limit - requested_output_tokens - reserved_tokens
+                    )
+                    fits = prompt_tokens <= safe_input_budget
+
+                    send_response(
+                        conn,
+                        {
+                            "id": request_id,
+                            "fits": fits,
+                            "prompt_tokens": prompt_tokens,
+                            "context_limit": context_limit,
+                            "requested_output_tokens": requested_output_tokens,
+                            "reserved_tokens": reserved_tokens,
+                            "safe_input_budget": safe_input_budget,
+                            "done": True,
+                        },
+                    )
+                except Exception as e:
+                    log(f"Prompt fit check failed: {e}", "error")
                     send_response(
                         conn, {"id": request_id, "error": str(e), "done": True}
                     )

--- a/scripts/mlx_bridge.py
+++ b/scripts/mlx_bridge.py
@@ -305,6 +305,132 @@ def send_response(conn: socket.socket, obj: dict) -> None:
         log(f"Failed to send response: {e}", "error")
 
 
+def build_vlm_prompt(processor_obj: Any, prompt_params: dict) -> str | None:
+    """Build a VLM prompt using the same template path as text_infer/vlm_infer."""
+    from mlx_vlm.prompt_utils import get_chat_template
+
+    messages = prompt_params.get("messages", [])
+    raw_prompt = prompt_params.get("rawPrompt")
+
+    if raw_prompt:
+        messages = [{"role": "user", "content": raw_prompt}]
+
+    if not messages:
+        return None
+
+    return get_chat_template(processor_obj, messages, add_generation_prompt=True)
+
+
+def count_prompt_tokens(tokenizer_obj: Any, prompt_text: str) -> int:
+    """Count prompt tokens across tokenizer return shapes."""
+    tokenized = tokenizer_obj.encode(prompt_text)
+    input_ids = getattr(tokenized, "input_ids", tokenized)
+    if isinstance(input_ids, dict):
+        input_ids = input_ids.get("input_ids", [])
+    if isinstance(input_ids, list) and input_ids and isinstance(input_ids[0], list):
+        return len(input_ids[0])
+    return len(input_ids)
+
+
+def resolve_context_limit(*candidates: Any, fallback_context_limit: int, request_id: int) -> int:
+    """Resolve model context limit from known config/tokenizer fields."""
+    field_names = (
+        "max_position_embeddings",
+        "max_seq_len",
+        "model_max_length",
+        "max_length",
+        "context_length",
+        "n_ctx",
+    )
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        for field_name in field_names:
+            value = getattr(candidate, field_name, None)
+            if isinstance(value, int) and value > 0 and value < 10_000_000:
+                return value
+
+    log(
+        f"Context limit metadata unavailable for request {request_id}; using fallback {fallback_context_limit}",
+        "error",
+    )
+    return fallback_context_limit
+
+
+def handle_text_prompt_fit(
+    conn: socket.socket,
+    model_obj: Any,
+    processor_obj: Any,
+    config_obj: Any,
+    params: dict,
+    request_id: int,
+) -> None:
+    """Check prompt fit for VLM-mode text generation using the text_infer prompt path."""
+    requested_output_tokens = int(params.get("maxTokens", 8000))
+    reserved_tokens = 24000
+    fallback_context_limit = 262144
+
+    try:
+        prompt = build_vlm_prompt(processor_obj, params)
+
+        if prompt is None:
+            send_response(
+                conn,
+                {
+                    "id": request_id,
+                    "error": "No prompt provided (need 'rawPrompt' or 'messages')",
+                    "done": True,
+                },
+            )
+            return
+
+        if not prompt:
+            send_response(
+                conn,
+                {
+                    "id": request_id,
+                    "error": "Empty prompt after template",
+                    "done": True,
+                },
+            )
+            return
+
+        tokenizer = getattr(processor_obj, "tokenizer", None)
+        if tokenizer is None:
+            raise ValueError("VLM tokenizer unavailable")
+
+        prompt_tokens = count_prompt_tokens(tokenizer, prompt)
+        context_limit = resolve_context_limit(
+            config_obj,
+            getattr(config_obj, "text_config", None),
+            getattr(model_obj, "config", None),
+            tokenizer,
+            getattr(tokenizer, "tokenizer", None),
+            fallback_context_limit=fallback_context_limit,
+            request_id=request_id,
+        )
+        safe_input_budget = context_limit - requested_output_tokens - reserved_tokens
+        fits = prompt_tokens <= safe_input_budget
+
+        send_response(
+            conn,
+            {
+                "id": request_id,
+                "fits": fits,
+                "prompt_tokens": prompt_tokens,
+                "context_limit": context_limit,
+                "requested_output_tokens": requested_output_tokens,
+                "reserved_tokens": reserved_tokens,
+                "safe_input_budget": safe_input_budget,
+                "done": True,
+            },
+        )
+    except Exception as e:
+        log(f"Prompt fit check failed: {e}", "error")
+        send_response(conn, {"id": request_id, "error": str(e), "done": True})
+
+
 
 
 def handle_vlm_infer(
@@ -322,7 +448,6 @@ def handle_vlm_infer(
     Output: raw text string + stats
     """
     from mlx_vlm import generate
-    from mlx_vlm.prompt_utils import get_chat_template
 
     global model, processor, config
 
@@ -345,7 +470,7 @@ def handle_vlm_infer(
         log(f"Processing VLM inference request", "debug")
 
         # Apply chat template
-        prompt = get_chat_template(processor_obj, messages, add_generation_prompt=True)
+        prompt = build_vlm_prompt(processor_obj, {"messages": messages})
 
         t_start = time.time()
 
@@ -479,6 +604,10 @@ def handle_request(
             # We call handle_vlm_infer directly — it already handles image=None
             # when no image paths are in the messages.
             handle_vlm_infer(
+                conn, model_obj, processor_obj, config_obj, params, request_id
+            )
+        elif method == "text_prompt_fit":
+            handle_text_prompt_fit(
                 conn, model_obj, processor_obj, config_obj, params, request_id
             )
         elif method == "load_llm":
@@ -693,45 +822,6 @@ def handle_request(
 
                         return None
 
-                    def count_prompt_tokens(tokenizer_obj: Any, prompt_text: str) -> int:
-                        tokenized = tokenizer_obj.encode(prompt_text)
-                        input_ids = getattr(tokenized, "input_ids", tokenized)
-                        if isinstance(input_ids, dict):
-                            input_ids = input_ids.get("input_ids", [])
-                        if isinstance(input_ids, list) and input_ids and isinstance(input_ids[0], list):
-                            return len(input_ids[0])
-                        return len(input_ids)
-
-                    def resolve_context_limit(model_ref: Any, tokenizer_obj: Any) -> int:
-                        candidates = [
-                            getattr(model_ref, "config", None),
-                            getattr(model_ref, "args", None),
-                            tokenizer_obj,
-                            getattr(tokenizer_obj, "tokenizer", None),
-                        ]
-                        field_names = (
-                            "max_position_embeddings",
-                            "max_seq_len",
-                            "model_max_length",
-                            "max_length",
-                            "context_length",
-                            "n_ctx",
-                        )
-
-                        for candidate in candidates:
-                            if candidate is None:
-                                continue
-                            for field_name in field_names:
-                                value = getattr(candidate, field_name, None)
-                                if isinstance(value, int) and value > 0 and value < 10_000_000:
-                                    return value
-
-                        log(
-                            f"Context limit metadata unavailable for request {request_id}; using fallback {fallback_context_limit}",
-                            "error",
-                        )
-                        return fallback_context_limit
-
                     prompt = build_llm_prompt(llm_tokenizer, params)
 
                     if prompt is None:
@@ -757,7 +847,14 @@ def handle_request(
                         return
 
                     prompt_tokens = count_prompt_tokens(llm_tokenizer, prompt)
-                    context_limit = resolve_context_limit(llm_model, llm_tokenizer)
+                    context_limit = resolve_context_limit(
+                        getattr(llm_model, "config", None),
+                        getattr(llm_model, "args", None),
+                        llm_tokenizer,
+                        getattr(llm_tokenizer, "tokenizer", None),
+                        fallback_context_limit=fallback_context_limit,
+                        request_id=request_id,
+                    )
                     safe_input_budget = (
                         context_limit - requested_output_tokens - reserved_tokens
                     )


### PR DESCRIPTION
## Summary

Adds two new dry-run preflight methods to \`mlx_bridge.py\` that let the Swift app check whether a prompt fits within a model's context window **before** submitting a real inference request. Also documents the cancellation investigation findings.

## New Methods

- **\`text_prompt_fit\`** — VLM-mode prompt fit check. Uses the same template path as \`text_infer\` (via \`get_chat_template\`). Returns \`fits\`, \`prompt_tokens\`, \`context_limit\`, \`safe_input_budget\`.
- **\`llm_prompt_fit\`** — LLM-mode prompt fit check. Uses \`apply_chat_template\` with the LLM tokenizer. Same response shape.

## New Shared Helpers

- \`build_vlm_prompt()\` — extracted from \`vlm_infer\` to share prompt-building logic
- \`count_prompt_tokens()\` — handles all tokenizer return shapes (list, nested list, dict)
- \`resolve_context_limit()\` — probes multiple config fields (\`max_position_embeddings\`, \`model_max_length\`, \`context_length\`, etc.) across model architectures to find the real limit, with a fallback of 262144

## Refactoring

- \`llm_infer\` handler now uses a local \`build_llm_prompt()\` instead of inline duplicated template logic
- VLM mode guard now also blocks \`llm_prompt_fit\` (not just \`llm_infer\`)

## Docs

- \`docs/learnings.md\` — adds **Artifact Generation Cancellation** investigation: why MLX \`generate()\` cannot be cancelled mid-run, all options evaluated (out-of-band signal, cooperative cancellation, process termination, socket disconnect), the decision not to implement, and alternative UX improvements to pursue instead.

## Why

Powers token-aware prompt budgeting in the Swift recorder app — the app calls \`text_prompt_fit\` / \`llm_prompt_fit\` as a preflight before trimming topic blocks to fit, avoiding silent truncation or context overflow errors at inference time.

Related work: \`feat/window-ui-redesign\` in https://github.com/eduardosanzb/escribano-app/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen